### PR TITLE
enable use of wfLoadSkin, the new way of loading skins

### DIFF
--- a/Neverland.php
+++ b/Neverland.php
@@ -493,6 +493,7 @@ class NeverlandTemplate extends BaseTemplate {
 
     <?php $this->printTrail(); ?>
   
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
     <script type="text/javascript" src="<?php echo $wgStylePath; ?>/Neverland/js/bootstrap.min.js"></script>
     <script type="text/javascript">
         /* Fix for Echo in Refreshed */

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,0 +1,7 @@
+{
+	"@metadata": {
+		"authors": []
+	},
+	"skinname-neverland": "Neverland",
+	"neverland-desc": "Modern version of MonoBook with fresh look and many usability improvements"
+}

--- a/skin.json
+++ b/skin.json
@@ -1,0 +1,31 @@
+{
+	"name": "Neverland",
+	"author": [
+		"..."
+	],
+	"url": "",
+	"descriptionmsg": "neverland-desc",
+	"namemsg": "skinname-neverland",
+	"license-name": "",
+	"type": "skin",
+	"ConfigRegistry": {
+		"neverland": "GlobalVarConfig::newInstance"
+	},
+	"ValidSkinNames": {
+		"neverland": "Neverland"
+	},
+	"MessagesDirs": {
+		"Vector": [
+			"i18n"
+		]
+	},
+	"AutoloadClasses": {
+		"SkinNeverland": "Neverland.php",
+		"NeverlandTemplate": "Neverland.php"
+	},
+	"config": {
+		"NeverlandUseSimpleSearch": true,
+		"NeverlandUseIconWatch": true
+	},
+	"manifest_version": 1
+}


### PR DESCRIPTION
Newest mediawiki versions and skins use a skin.json now, which enables the use of wfLoadSkin().
