### PR TITLE
Fixed T3268. Content:13pt ,Toolbar:14px

### DIFF
--- a/css/bootstrap.css
+++ b/css/bootstrap.css
@@ -5780,7 +5780,7 @@ tt {
 blockquote {
   font-style: italic; }
 
-.content {
+#content {
   font-size: 13pt;
   line-height: 1.5em; }
 
@@ -6744,6 +6744,9 @@ ul.special,
 
 .oo-ui-window-frame * {
   box-sizing: content-box; }
+
+div.oo-ui-toolbar-bar {
+  font-size: 14px; }
 
 .oo-ui-toolbar-bar .oo-ui-popupToolGroup.oo-ui-labelElement.oo-ui-indicatorElement .oo-ui-popupToolGroup-handle .oo-ui-labelElement-label {
   margin-right: 1.2em !important;


### PR DESCRIPTION
This is regarding : https://phabricator.kde.org/T3268

It keeps the size of content in the editor same with the view one. ( content : 13pt and toolbar has 14px)
